### PR TITLE
Clarify local development and fix Jekyll's ignoring of site changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,5 @@ end
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
+
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,10 +249,12 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
+    webrick (1.7.0)
     zeitwerk (2.4.2)
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
 
 DEPENDENCIES
   github-pages (~> 209)
@@ -261,6 +263,7 @@ DEPENDENCIES
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)
+  webrick (~> 1.7)
 
 BUNDLED WITH
    2.2.3

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# ECEReporter-Help
- Help guides for the ECE Reporter app
+# ECE Reporter Help
+ A collection of help guides for the ECE Reporter application.
+
+ ## Local Setup
+1. Install and configure [Jekyll and all its prerequisites](https://jekyllrb.com/docs/installation/).
+
+1. Assuming Ruby and Bundler have been installed successfully, update Bundler.
+    ```
+    gem install bundler
+    ```
+
+1. From project root, install all Ruby dependencies.
+    ```
+    bundle install
+    ```
+
+1. Start up the application!
+    ```
+    bundle exec jekyll serve
+    ```

--- a/_config.yml
+++ b/_config.yml
@@ -25,9 +25,10 @@ description: >- # this means to ignore newlines until "baseurl:"
 #baseurl: "/ece-reporter-support/" # the subpath of your site, e.g. /blog
 url: "https://help.ece-reporter.ctoec.org/" # the base hostname & protocol for your site, e.g. http://example.com
 
-
 # Build settings
 remote_theme: pmarsceill/just-the-docs
+source: _site
+destination: dist
 
 # Aux links for the upper right navigation
 aux_links:


### PR DESCRIPTION
Minor PR that includes a few different pieces:

- Specify distinct `source` and `destination` directories for builds, so that site changes are _actually_ propagated out
- Add barebones instructions to get set up for local development
- Add `webrick` dependency to get around a [known Jekyll issue](https://github.com/jekyll/jekyll/issues/8523) preventing local development with Ruby 3.0+
